### PR TITLE
Update bindtogateway.ps1

### DIFF
--- a/bindtogateway.ps1
+++ b/bindtogateway.ps1
@@ -46,7 +46,11 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
+    
+    $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, $platParam)
 
     return $authResult
 }

--- a/takeover-dataset.ps1
+++ b/takeover-dataset.ps1
@@ -44,7 +44,11 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    
+    $authTask.Wait()
+    
+    $authResult = $authTask.Result
 
     return $authResult
 }


### PR DESCRIPTION
AcquireToken signature changed in v3 of the ADAL library.  Now instead of a string for last parameter, it requires a Platform Parameter Object.