### PR TITLE
Add requirements for ADAL v3 and updated gateway endpoint to conform to PBI API v2 reqs

### DIFF
--- a/Zero-Downtime-Capacity-Scale.ps1
+++ b/Zero-Downtime-Capacity-Scale.ps1
@@ -120,7 +120,15 @@ FUNCTION GetAuthToken
     }
     ELSE
     {
-        $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, 'Always')
+        $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Always
+
+        $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+        $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+
+        $authTask.Wait()
+
+        $authResult = $authTask.Result
     }
 
     return $authResult

--- a/bindtogateway.ps1
+++ b/bindtogateway.ps1
@@ -46,7 +46,11 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
+    
+    $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, $platParam)
 
     return $authResult
 }

--- a/bindtogateway.ps1
+++ b/bindtogateway.ps1
@@ -47,10 +47,14 @@ function GetAuthToken
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
     $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
-    
+
     $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+
+    $authTask.Wait()
+
+    $authResult = $authTask.Result
 
     return $authResult
 }

--- a/copyWorkspace.ps1
+++ b/copyWorkspace.ps1
@@ -43,7 +43,15 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
+
+    $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+
+    $authTask.Wait()
+
+    $authResult = $authTask.Result
 
     return $authResult
 }

--- a/manageRefresh.ps1
+++ b/manageRefresh.ps1
@@ -46,8 +46,16 @@ function GetAuthToken
        $authority = "https://login.microsoftonline.com/common/oauth2/authorize";
  
        $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
- 
-       $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+
+       $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
+
+       $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+       $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+
+       $authTask.Wait()
+
+       $authResult = $authTask.Result
  
        return $authResult
 }

--- a/rebindReport.ps1
+++ b/rebindReport.ps1
@@ -60,7 +60,15 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
+
+    $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+
+    $authTask.Wait()
+
+    $authResult = $authTask.Result
 
     return $authResult
 }

--- a/takeover-dataset.ps1
+++ b/takeover-dataset.ps1
@@ -44,10 +44,14 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, "Auto")
-    
+    $promptBehav = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
+
+    $platParam = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehav
+
+    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platParam)
+
     $authTask.Wait()
-    
+
     $authResult = $authTask.Result
 
     return $authResult

--- a/takeover-dataset.ps1
+++ b/takeover-dataset.ps1
@@ -44,7 +44,11 @@ function GetAuthToken
 
     $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    $authTask = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, "Auto")
+    
+    $authTask.Wait()
+    
+    $authResult = $authTask.Result
 
     return $authResult
 }

--- a/takeover-dataset.ps1
+++ b/takeover-dataset.ps1
@@ -16,6 +16,7 @@
 
 $groupId = " FILL ME IN "           # the ID of the group (workspace) that hosts the dataset.
 $datasetId = " FILL ME IN "         # the ID of dataset to rebind
+$gatewayId = " FILL ME IN "         # the ID of gateway to bind to
 
 # AAD Client ID
 # To get this, go to the following page and follow the steps to provision an app
@@ -75,11 +76,17 @@ if ($groupId -eq "me") {
 }
 
 # Make the request to bind to a gateway
-$uri = "https://api.powerbi.com/v1.0/$sourceGroupsPath/datasets/$datasetId/BindToGateway"
+$uri = "https://api.powerbi.com/v1.0/$sourceGroupsPath/datasets/$datasetId/Default.BindToGateway"
+
+$gatewayObject = @{
+    gatewayObjectId = $gatewayId
+}
+
+$postBodyJson = $gatewayObject | ConvertTo-Json
 
 # Try to bind to a new gateway
 try {
-    Invoke-RestMethod -Uri $uri -Headers $authHeader -Method POST -Verbose 
+    Invoke-RestMethod -Uri $uri -Headers $authHeader -Body $postBodyJson -Method POST -Verbose 
 } catch {
 
     $result = $_.Exception.Response.GetResponseStream()


### PR DESCRIPTION
AcquireToken signature changed in v3 of the ADAL library. Now instead of a string for the final parameter, it requires a Platform Parameter Object. Made async changes as AcquireToken was deprecated in v3, replaced with AcquireTokenAsync. BindToGateway Endpoint has changed for takeover-dataset.ps1 and now expects the gateway id in POST body.  Added variables and serialization to handle this.