### PR TITLE
Update manageRefresh.ps1 to fix error

### DIFF
--- a/manageRefresh.ps1
+++ b/manageRefresh.ps1
@@ -71,8 +71,8 @@ if ($groupID -eq "me") {
 
 # Refresh the dataset
 $uri = "https://api.powerbi.com/v1.0/$groupsPath/datasets/$datasetID/refreshes"
-Invoke-RestMethod -Uri $uri –Headers $authHeader –Method POST –Verbose
+Invoke-RestMethod -Uri $uri -Headers $authHeader -Method POST -Verbose
 
 # Check the refresh history
 $uri = "https://api.powerbi.com/v1.0/$groupsPath/datasets/$datasetID/refreshes"
-Invoke-RestMethod -Uri $uri –Headers $authHeader –Method GET –Verbose
+Invoke-RestMethod -Uri $uri -Headers $authHeader -Method GET -Verbose


### PR DESCRIPTION
In issue #5, it's pointed out in a [comment](https://github.com/Azure-Samples/powerbi-powershell/issues/5#issuecomment-365752905) that the `Invoke-RestMethod` parameter names have long dashes, which causes problems. This changes the en dashes to dashes (`–` to `-`), which fixed the error.